### PR TITLE
test_prbs: Handle PRBS error counter wrap around

### DIFF
--- a/bench/serdes/test_prbs.py
+++ b/bench/serdes/test_prbs.py
@@ -125,6 +125,8 @@ def prbs_test(csr_csv="csr.csv", port=1234, serdes=0, mode="prbs7", square_wave=
             serdes.rx_prbs_config.write(prbs_pause | prbs_modes[mode])
             errors = serdes.rx_prbs_errors.read()
             serdes.rx_prbs_config.write(prbs_modes[mode])
+            if errors < errors_last:
+                errors_last -= 1 << 32
             if not first:
                 errors_total += (errors - errors_last)
             # Log

--- a/liteiclink/serdes/gth_ultrascale.py
+++ b/liteiclink/serdes/gth_ultrascale.py
@@ -859,7 +859,7 @@ class GTH(Module, AutoCSR):
         ]
 
         # RX Datapath and PRBS ---------------------------------------------------------------------
-        self.submodules.rx_prbs = ClockDomainsRenamer("rx")(PRBSRX(data_width, True))
+        self.submodules.rx_prbs = ClockDomainsRenamer("rx")(PRBSRX(data_width, True, wrap=True))
         self.comb += [
             self.rx_prbs.config.eq(rx_prbs_config),
             self.rx_prbs.pause.eq(rx_prbs_pause),

--- a/liteiclink/serdes/gtp_7series.py
+++ b/liteiclink/serdes/gtp_7series.py
@@ -999,7 +999,7 @@ class GTP(Module, AutoCSR):
         ]
 
         # RX Datapath and PRBS ---------------------------------------------------------------------
-        self.submodules.rx_prbs = ClockDomainsRenamer("rx")(PRBSRX(data_width, True))
+        self.submodules.rx_prbs = ClockDomainsRenamer("rx")(PRBSRX(data_width, True, wrap=True))
         self.comb += [
             self.rx_prbs.config.eq(rx_prbs_config),
             self.rx_prbs.pause.eq(rx_prbs_pause),

--- a/liteiclink/serdes/gtx_7series.py
+++ b/liteiclink/serdes/gtx_7series.py
@@ -1028,7 +1028,7 @@ class GTX(Module, AutoCSR):
         ]
 
         # RX Datapath and PRBS ---------------------------------------------------------------------
-        self.submodules.rx_prbs = ClockDomainsRenamer("rx")(PRBSRX(data_width, True))
+        self.submodules.rx_prbs = ClockDomainsRenamer("rx")(PRBSRX(data_width, True, wrap=True))
         self.comb += [
             self.rx_prbs.config.eq(rx_prbs_config),
             self.rx_prbs.pause.eq(rx_prbs_pause),

--- a/liteiclink/serdes/gty_ultrascale.py
+++ b/liteiclink/serdes/gty_ultrascale.py
@@ -1138,7 +1138,7 @@ class GTY(Module, AutoCSR):
         ]
 
         # RX Datapath and PRBS ---------------------------------------------------------------------
-        self.submodules.rx_prbs = ClockDomainsRenamer("rx")(PRBSRX(data_width, True))
+        self.submodules.rx_prbs = ClockDomainsRenamer("rx")(PRBSRX(data_width, True, wrap=True))
         self.comb += [
             self.rx_prbs.config.eq(rx_prbs_config),
             self.rx_prbs.pause.eq(rx_prbs_pause),

--- a/liteiclink/serdes/serdes_ecp5.py
+++ b/liteiclink/serdes/serdes_ecp5.py
@@ -696,7 +696,7 @@ class SerDesECP5(Module, AutoCSR):
         ]
 
         # RX Datapath and PRBS ---------------------------------------------------------------------
-        self.submodules.rx_prbs = ClockDomainsRenamer("rx")(PRBSRX(data_width, True))
+        self.submodules.rx_prbs = ClockDomainsRenamer("rx")(PRBSRX(data_width, True, wrap=True))
         self.comb += [
             self.rx_prbs.config.eq(rx_prbs_config),
             self.rx_prbs.pause.eq(rx_prbs_pause),


### PR DESCRIPTION
Previously if the PRBS counter reached its max value of 0xffffffff,
the reported number of errors would drop to 0. And this happens
pretty quickly given the fast data rates.

Now we enable the new 'wrap' option of PRBSRX core so that the counter
wraps to 0 on overflows and we detect and handle that condition in
test_prbs.py

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>