### PR TITLE
serwb: Fix shifting

### DIFF
--- a/liteiclink/serwb/kuserdes.py
+++ b/liteiclink/serwb/kuserdes.py
@@ -102,7 +102,7 @@ class _KUSerdesRX(Module):
         # Control
         self.delay_rst     = Signal()
         self.delay_inc     = Signal()
-        self.shift = shift = Signal(6)
+        self.shift_inc = shift_inc = Signal()
 
         # Status
         self.idle  = idle = Signal()
@@ -158,7 +158,7 @@ class _KUSerdesRX(Module):
         self.comb += [
             datapath.sink.valid.eq(1),
             datapath.sink.data.eq(data),
-            datapath.shift.eq(shift),
+            datapath.shift_inc.eq(shift_inc),
             datapath.source.connect(source),
             idle.eq(datapath.idle),
             comma.eq(datapath.comma)

--- a/liteiclink/serwb/phy.py
+++ b/liteiclink/serwb/phy.py
@@ -105,7 +105,6 @@ class _SerdesMasterInit(Module):
             ),
             serdes.tx.comma.eq(1)
         )
-        self.comb += serdes.rx.shift.eq(shift)
         fsm.act("INC-DELAY-SHIFT",
             NextState("WAIT-STABLE"),
             If(delay == (taps - 1),
@@ -116,7 +115,8 @@ class _SerdesMasterInit(Module):
                     NextValue(delay_min,       0),
                     NextValue(delay_max_found, 0),
                     NextValue(delay_max,       0),
-                    NextValue(shift, shift + 1)
+                    NextValue(shift, shift + 1),
+                    serdes.rx.shift_inc.eq(1)
                 ),
                 NextValue(delay, 0),
                 serdes.rx.delay_rst.eq(1)
@@ -171,7 +171,7 @@ class _SerdesSlaveInit(Module, AutoCSR):
         self.delay_min_found = delay_min_found = Signal()
         self.delay_max       = delay_max       = Signal(max=taps)
         self.delay_max_found = delay_max_found = Signal()
-        self.shift         = shift         = Signal(max=40)
+        self.shift           = shift           = Signal(max=40)
 
         # Timer
         self.submodules.timer = timer = WaitTimer(timeout)
@@ -224,7 +224,6 @@ class _SerdesSlaveInit(Module, AutoCSR):
             ),
             serdes.tx.idle.eq(1)
         )
-        self.comb += serdes.rx.shift.eq(shift)
         fsm.act("INC-DELAY-SHIFT",
             NextState("WAIT-STABLE"),
             If(delay == (taps - 1),
@@ -235,7 +234,8 @@ class _SerdesSlaveInit(Module, AutoCSR):
                     NextValue(delay_min,       0),
                     NextValue(delay_max_found, 0),
                     NextValue(delay_max,       0),
-                    NextValue(shift, shift + 1)
+                    NextValue(shift, shift + 1),
+                    serdes.rx.shift_inc.eq(1)
                 ),
                 NextValue(delay, 0),
                 serdes.rx.delay_rst.eq(1)

--- a/liteiclink/serwb/s7serdes.py
+++ b/liteiclink/serwb/s7serdes.py
@@ -118,7 +118,7 @@ class _S7SerdesRX(Module):
         # Control
         self.delay_rst     = Signal()
         self.delay_inc     = Signal()
-        self.shift         = Signal()
+        self.shift_inc     = Signal()
 
         # Status
         self.idle  = idle = Signal()
@@ -130,7 +130,7 @@ class _S7SerdesRX(Module):
         # # #
 
         _shift = Signal(3)
-        self.sync += If(self.shift, _shift.eq(_shift + 1))
+        self.sync += If(self.shift_inc, _shift.eq(_shift + 1))
 
         # Data input (DDR with sys4x)
         data_nodelay      = Signal()
@@ -170,7 +170,7 @@ class _S7SerdesRX(Module):
                 i_CLK     = ClockSignal("sys4x"),
                 i_CLKB    =~ClockSignal("sys4x"),
                 i_CLKDIV  = ClockSignal("sys"),
-                i_BITSLIP = self.shift,
+                i_BITSLIP = self.shift_inc,
                 o_Q8      = data[0],
                 o_Q7      = data[1],
                 o_Q6      = data[2],
@@ -187,7 +187,7 @@ class _S7SerdesRX(Module):
         self.comb += [
             datapath.sink.valid.eq(1),
             datapath.sink.data.eq(data),
-            datapath.shift.eq(self.shift & (_shift == 0b111)),
+            datapath.shift_inc.eq(self.shift_inc & (_shift == 0b111)),
             datapath.source.connect(source),
             idle.eq(datapath.idle),
             comma.eq(datapath.comma)

--- a/test/test_serwb_init.py
+++ b/test/test_serwb_init.py
@@ -27,7 +27,7 @@ class SerdesModel(Module):
         self.rx.idle      = Signal()
         self.rx.comma     = Signal()
 
-        self.rx.shift     = Signal(6)
+        self.rx.shift_inc = Signal()
         self.rx.delay_rst = Signal()
         self.rx.delay_inc = Signal()
 
@@ -44,7 +44,9 @@ class SerdesModel(Module):
             self.comb += valid_delays[taps-1-i].eq(self.valid_delays[i])
 
         self.sync += [
-            shift.eq(self.rx.shift),
+            If(self.rx.shift_inc,
+                shift.eq(shift+1)
+            ),
             If(self.rx.delay_rst,
                 delay.eq(0)
             ).Elif(self.rx.delay_inc,


### PR DESCRIPTION
What was the problem:
The liteiclink init process between a Kintex 7 and a Virtex 7 was very unreliable.

Why:
There was some confusion about the counter that should keep track of how many shifts have been done and the signal that indicates that a shift should now be done. 
For example, the bitslip signal on the s7serdes initiates a bitslip every clkdiv tick. So it should not be asserted for more than one consecutive clk, which is not the case at the moment because it is derived from the shift counter.

What I did:
* Added help text to RXAligner.
* Renamed shift to shift_inc in places where it is only allowed to stay 1 for one cycle.
* Changed phy statemachine to only assert shift_inc for one cycle.

Unfortunately, the phy classes don't have any unit tests to verify their functionality. 
But I don't have a clue how to improve this situation.

~~A final test of this PR on real HW with the s7serdes will be done on 30.05.23.~~
This PR was tested on a Virtex7-Virtex7 connection over multiple connectors and a Virtex7-Kintex7 connection on the same pcb. The sync process was much more reliable.
I was not able to test the kuserdes (I don't have the HW).