### PR TITLE
Compatibility with Zynq7000 FPGAs

### DIFF
--- a/liteiclink/serwb/phy.py
+++ b/liteiclink/serwb/phy.py
@@ -408,11 +408,7 @@ class SERWBPHY(LiteXModule):
             assert clk_ratio == "1:1"
             taps = 512
             self.serdes = KUSerdes(pads, mode)
-        elif device[:4] == "xc7a":
-            assert clk_ratio == "1:1"
-            taps = 32
-            self.serdes = S7Serdes(pads, mode)
-        elif device[:4] == "xc7z":
+        elif device[:4] in ["xc7a", "xc7z"]:
             assert clk_ratio == "1:1"
             taps = 32
             self.serdes = S7Serdes(pads, mode)

--- a/liteiclink/serwb/phy.py
+++ b/liteiclink/serwb/phy.py
@@ -412,6 +412,10 @@ class SERWBPHY(LiteXModule):
             assert clk_ratio == "1:1"
             taps = 32
             self.serdes = S7Serdes(pads, mode)
+        elif device[:4] == "xc7z":
+            assert clk_ratio == "1:1"
+            taps = 32
+            self.serdes = S7Serdes(pads, mode)
         elif device[:2] == "Ti":
             taps = 64
             self.serdes = EfinixSerdes(pads, mode,


### PR DESCRIPTION
Simple as it is, adds compatibility with Zynq7000 series based FPGA dev boards like Digilent Zybo/ Zybo Z7, ZedBoard, Artix Z7 and so on...