### PR TITLE
Fix GTY Channel Simulation

### DIFF
--- a/liteiclink/serdes/gty_ultrascale.py
+++ b/liteiclink/serdes/gty_ultrascale.py
@@ -1012,7 +1012,7 @@ class GTY(LiteXModule):
             i_TXPHALIGN       = 0,
             i_TXPHALIGNEN     = 0,
             i_TXPHINIT        = 0,
-            o_TXPHINITDONE    = 0,
+            o_TXPHINITDONE    = tx_init.Xxphinitdone,
             o_TXPHALIGNDONE   = tx_init.Xxphaligndone,
             i_TXUSERRDY       = tx_init.Xxuserrdy,
             i_TXPHDLYPD       = 1 if tx_buffer_enable else 0,

--- a/liteiclink/serdes/gty_ultrascale_init.py
+++ b/liteiclink/serdes/gty_ultrascale_init.py
@@ -31,6 +31,7 @@ class GTYInit(LiteXModule):
         self.Xxresetdone     = Signal() # i
         self.Xxdlysreset     = Signal() # o
         self.Xxdlysresetdone = Signal() # i
+        self.Xxphinitdone    = Signal() # o
         self.Xxphaligndone   = Signal() # i
         self.Xxsyncdone      = Signal() # i
         self.Xxuserrdy       = Signal() # o


### PR DESCRIPTION
This PR fixes a simulation issue with the GTY module.  Instead of connecting the INITDONE output to a constant zero, a new signal is created and connected to it instead.  This stops the simulator complaining that the output is being driven and enables it to run successfully.

Resolves #24 