### PR TITLE
gt*_init.py: deglitch the pllreset signal

### DIFF
--- a/liteiclink/serdes/gth_7series_init.py
+++ b/liteiclink/serdes/gth_7series_init.py
@@ -60,11 +60,13 @@ class GTHInit(LiteXModule):
         self.comb += Xxphaligndone_rising.eq(Xxphaligndone & ~Xxphaligndone_r)
 
         # Deglitch FSM outputs driving transceiver asynch inputs
+        pllreset    = Signal()
         gtXxreset   = Signal()
         gtXxpd      = Signal()
         Xxdlysreset = Signal()
         Xxuserrdy   = Signal()
         self.sync += [
+            self.pllreset.eq(pllreset),
             self.gtXxreset.eq(gtXxreset),
             self.gtXxpd.eq(gtXxpd),
             self.Xxdlysreset.eq(Xxdlysreset),
@@ -76,12 +78,12 @@ class GTHInit(LiteXModule):
         fsm.act("POWER-DOWN",
             gtXxreset.eq(1),
             gtXxpd.eq(1),
-            self.pllreset.eq(1),
+            pllreset.eq(1),
             NextState("DRP")
         )
         fsm.act("DRP",
             gtXxreset.eq(1),
-            self.pllreset.eq(1),
+            pllreset.eq(1),
             self.drp_start.eq(1),
             If(self.drp_done,
                 NextState("WAIT-PLL-RESET")
@@ -153,7 +155,7 @@ class GTHInit(LiteXModule):
             watchdog.wait.eq(~fsm.reset & ~self.done),
             fsm.reset.eq(self.restart | watchdog.done)
         ]
-        
+
 # GTH TX Init --------------------------------------------------------------------------------------
 
 class GTHTXInit(GTHInit):

--- a/liteiclink/serdes/gth_ultrascale_init.py
+++ b/liteiclink/serdes/gth_ultrascale_init.py
@@ -56,11 +56,13 @@ class GTHInit(LiteXModule):
         ]
 
         # Deglitch FSM outputs driving transceiver asynch inputs.
+        pllreset    = Signal()
         gtXxreset   = Signal()
         gtXxpd      = Signal()
         Xxdlysreset = Signal()
         Xxuserrdy   = Signal()
         self.sync += [
+            self.pllreset.eq(pllreset),
             self.gtXxreset.eq(gtXxreset),
             self.gtXxpd.eq(gtXxpd),
             self.Xxdlysreset.eq(Xxdlysreset),
@@ -93,7 +95,7 @@ class GTHInit(LiteXModule):
         fsm.act("POWER_DOWN",
             gtXxreset.eq(1),
             gtXxpd.eq(1),
-            self.pllreset.eq(1),
+            pllreset.eq(1),
             pll_reset_timer.wait.eq(1),
             If(pll_reset_timer.done,
                 NextState("DRP")
@@ -101,7 +103,7 @@ class GTHInit(LiteXModule):
         )
         fsm.act("DRP",
             gtXxreset.eq(1),
-            self.pllreset.eq(1),
+            pllreset.eq(1),
             self.drp_start.eq(1),
             If(self.drp_done,
                 NextState("RELEASE_PLL_RESET")

--- a/liteiclink/serdes/gtp_7series_init.py
+++ b/liteiclink/serdes/gtp_7series_init.py
@@ -60,6 +60,7 @@ class GTPTXInit(LiteXModule):
         ]
 
         # Deglitch FSM outputs driving transceiver asynch inputs.
+        pllreset    = Signal()
         gttxreset   = Signal()
         gttxpd      = Signal()
         txdlysreset = Signal()
@@ -68,6 +69,7 @@ class GTPTXInit(LiteXModule):
         txdlyen     = Signal()
         txuserrdy   = Signal()
         self.sync += [
+            self.pllreset.eq(pllreset),
             self.gttxreset.eq(gttxreset),
             self.gttxpd.eq(gttxpd),
             self.txdlysreset.eq(txdlysreset),
@@ -88,12 +90,12 @@ class GTPTXInit(LiteXModule):
         fsm.act("POWER-DOWN",
             gttxreset.eq(1),
             gttxpd.eq(1),
-            self.pllreset.eq(1),
+            pllreset.eq(1),
             NextState("DRP")
         )
         fsm.act("DRP",
             gttxreset.eq(1),
-            self.pllreset.eq(1),
+            pllreset.eq(1),
             self.drp_start.eq(1),
             If(self.drp_done,
                 NextState("WAIT-PLL-RESET")

--- a/liteiclink/serdes/gtx_7series_init.py
+++ b/liteiclink/serdes/gtx_7series_init.py
@@ -58,11 +58,13 @@ class GTXInit(LiteXModule):
         self.comb += Xxphaligndone_rising.eq(Xxphaligndone & ~Xxphaligndone_r)
 
         # Deglitch FSM outputs driving transceiver asynch inputs.
+        pllreset    = Signal()
         gtXxreset   = Signal()
         gtXxpd      = Signal()
         Xxdlysreset = Signal()
         Xxuserrdy   = Signal()
         self.sync += [
+            self.pllreset.eq(pllreset),
             self.gtXxreset.eq(gtXxreset),
             self.gtXxpd.eq(gtXxpd),
             self.Xxdlysreset.eq(Xxdlysreset),
@@ -74,12 +76,12 @@ class GTXInit(LiteXModule):
         fsm.act("POWER-DOWN",
             gtXxreset.eq(1),
             gtXxpd.eq(1),
-            self.pllreset.eq(1),
+            pllreset.eq(1),
             NextState("DRP")
         )
         fsm.act("DRP",
             gtXxreset.eq(1),
-            self.pllreset.eq(1),
+            pllreset.eq(1),
             self.drp_start.eq(1),
             If(self.drp_done,
                 NextState("WAIT-PLL-RESET")

--- a/liteiclink/serdes/gty_ultrascale_init.py
+++ b/liteiclink/serdes/gty_ultrascale_init.py
@@ -56,11 +56,13 @@ class GTYInit(LiteXModule):
         ]
 
         # Deglitch FSM outputs driving transceiver asynch inputs.
+        pllreset    = Signal()
         gtXxreset   = Signal()
         gtXxpd      = Signal()
         Xxdlysreset = Signal()
         Xxuserrdy   = Signal()
         self.sync += [
+            self.pllreset.eq(pllreset),
             self.gtXxreset.eq(gtXxreset),
             self.gtXxpd.eq(gtXxpd),
             self.Xxdlysreset.eq(Xxdlysreset),
@@ -93,7 +95,7 @@ class GTYInit(LiteXModule):
         fsm.act("POWER_DOWN",
             gtXxreset.eq(1),
             gtXxpd.eq(1),
-            self.pllreset.eq(1),
+            pllreset.eq(1),
             pll_reset_timer.wait.eq(1),
             If(pll_reset_timer.done,
                 NextState("DRP")
@@ -101,7 +103,7 @@ class GTYInit(LiteXModule):
         )
         fsm.act("DRP",
             gtXxreset.eq(1),
-            self.pllreset.eq(1),
+            pllreset.eq(1),
             self.drp_start.eq(1),
             If(self.drp_done,
                 NextState("RELEASE_PLL_RESET")


### PR DESCRIPTION
I've been testing the TX part of the the GTP transceiver on hardware with litescope (berkeleylab_obsidian platform).
I have the internal FIFO enabled (`tx_buffer_enable=True`).

I've noticed that for some builds (but not always), the QuadPLL looses lock during initialization.

Here's an example, captured with litescope:

<img width="910" height="345" alt="ksnip_20251024-222533" src="https://github.com/user-attachments/assets/7fc22f88-311c-43ed-af84-fb9e85a65b56" />

Because the QPLL needs some time to re-gain lock, this leads to a buffer underflow and the corresponding error flag in `TXBUFSTATUS[1]` gets latched.

The problem seems to be caused by glitches on the `pllreset` signal going to the QPLL. These glitches are not captured by litescope but seem to lead to an unintentional reset of the QPLL. 

After applying this patch, the problem has disappeared and the PLL stays locked.